### PR TITLE
Refactor memory mapped devices

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,7 @@ find_package(Qt6 REQUIRED COMPONENTS
     ${QT_REQUIRED_COMPONENTS}
 )
 
+
 include(FetchContent)
 FetchContent_Declare(SFML
     GIT_REPOSITORY https://github.com/SFML/SFML.git

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,6 @@
 !#/bin/bash/
 if cmake  -DCMAKE_PREFIX_PATH=~/Qt/6.8.0/gcc_64/ -DCMAKE_CXX_FLAGS="-std=c++17"  -S . -B build; then
-    if cmake  --build build --config Release; then  
+    if cmake  --build build --config Release -j8; then  
         ./build/TetroidNES
     else 
         echo "compiler error"

--- a/src/emulator/PPU.cpp
+++ b/src/emulator/PPU.cpp
@@ -276,36 +276,12 @@ void PPU::log_ppu()
 
     qInfo() << "===== PPU status ====";
     this->ppustatus.log();
-    // qInfo() << "VBlank: " << this->reg.ppuStatus.V;
-    // qInfo() << "0_hit: " << this->reg.ppuStatus.S;
-    // qInfo() << "overflow: " << this->reg.ppuStatus.O;
-    // qInfo() << "status: " << ppu_status.to_string();
     qInfo() << "";
-
     qInfo() << "===== PPU ctrl ====";
     this->ppuctrl.log();
-    // qInfo() << "NMI enable (0: off, 1: on): " << this->reg.ppuCtrl.V;
-    // qInfo() << "PPU master/slave select (0: read backdrop from EXT pins; 1: output color on EXT pins): " << this->reg.ppuCtrl.P;
-    // qInfo() << "sprite size (0: 8x8, 1: 8x16): " << this->reg.ppuCtrl.H;
-    // qInfo() << "Background patterntable (0: $0000; 1: $1000): " << this->reg.ppuCtrl.B;
-    // qInfo() << "Sprite patterntable (0: $0000; 1: $1000): " << this->reg.ppuCtrl.S;
-    // qInfo() << "increment (0: add 1 going across, 1: add 32 going down): " << this->reg.ppuCtrl.I;
-    // std::bitset<2> name_table_address(this->reg.ppuCtrl.N);
-    // qInfo() << "name table addreess: " << name_table_address.to_string();
-    // qInfo() << "ctrl: " << ppu_ctrl.to_string();
     qInfo() << "";
     qInfo() << "===== PPU mask ====";
     this->ppumask.log();
-    // qInfo() << "Emphasize blue: " << this->reg.ppumask.B;
-    // qInfo() << "Emphasize green: " << this->reg.ppumask.G;
-    // qInfo() << "Emphasize red: " << this->reg.ppumask.R;
-
-    // qInfo() << "Enable sprite rendering: " << this->reg.ppumask.s;
-    // qInfo() << "Enable background rendering: " << this->reg.ppumask.b;
-    // qInfo() << "Show sprites in leftmost 8 pixels of screen: " << this->reg.ppumask.M;
-    // qInfo() << "Show background in leftmost 8 pixels of screen " << this->reg.ppumask.m;
-    // qInfo() << "grey scale (0: normal color, 1: grey scale): " << this->reg.ppumask.g;
-    // qInfo() << "ppu mask: " << ppu_mask.to_string();
     qInfo() << "";
 }
 void PPU::write_PPU_address(uint8_t val)
@@ -319,7 +295,6 @@ void PPU::write_PPU_ctrl(uint8_t val)
     if (before == 0 && this->ppuctrl.get_bit(7) == 1 && this->ppustatus.get_bit(7) == 1)
     {
         this->ppuctrl.set_bit(7, 1);
-        // this->reg.ppuCtrl.V = 1;
     }
 }
 void PPU::write_PPU_mask(uint8_t val)
@@ -345,15 +320,8 @@ std::optional<int> PPU::write_PPU_data(uint8_t val)
     // std::cout << addr << std::endl;
     if (addr >= 0x2000 && addr <= 0x2fff)
     {
-        // uint8_t res = internalDataBuffer;
-        // if (this->reg.ppumask.b == 0)
-        // {
-        //     // printf("is 0 \n");
-        //     return 1;
-        // }
+
         this->memory[mirror(addr)] = val;
-        // std::cout << "saving to vram" << std::endl;
-        // internalDataBuffer = memory[mirror(addr)];
     }
     else if (addr == 0x3f10 || addr == 0x3f14 || addr == 0x3f18 || addr == 0x3f1c)
     {

--- a/src/emulator/PPU.cpp
+++ b/src/emulator/PPU.cpp
@@ -4,6 +4,7 @@
 #include <Emulator/PPU.h>
 #include <Emulator/EmulatorUtil.h>
 #include <Qt/util.h>
+#include <optional>
 #include <bitset>
 #include <Qt/util.h>
 #include <QDebug>
@@ -14,7 +15,8 @@ PPU::PPU(std::vector<uint8_t> chrrom, MirrorType mirrorType)
     this->chr_rom = chrrom;
     this->mirrorType = mirrorType;
     this->internalDataBuffer = 0;
-    this->reg.ppuAddr.val = 0;
+    // this->reg.ppuAddr.val = 0;
+    this->ppuaddr.reset();
     this->reg.ppuCtrl.val = 0;
     this->reg.ppuStatus.val = 0;
 
@@ -201,10 +203,12 @@ uint16_t PPU::mirror(uint16_t address)
 
 uint8_t PPU::read_PPU_data()
 {
-    uint16_t addr = this->reg.ppuAddr.val;
-    printf("pallete \n");
+    uint16_t addr = this->ppuaddr.read_16bit();
 
-    this->reg.ppuAddr.val += reg.ppuCtrl.I ? 32 : 1;
+    uint16_t c = this->ppuaddr.read_16bit() + ((reg.ppuCtrl.I) ? 32 : 1);
+    this->ppuaddr.write_16bit(c);
+    // printf("pallete \n");
+    // this->reg.ppuAddr.val += reg.ppuCtrl.I ? 32 : 1;
     if (addr <= 0x1fff)
     {
         uint8_t res = internalDataBuffer;
@@ -240,14 +244,14 @@ void PPU::print_ppu_stats()
     printf("===== PPU ON EXIT =========== \n");
     printf("\n");
 
-    printf("ppu_addr:  decimal: %d hexa: 0x%x   \n", this->reg.ppuAddr.val, this->reg.ppuAddr.val);
-    printf("ppu_addr hi: decimal: %d hexa: 0x%x\n", this->reg.ppuAddr.hi, this->reg.ppuAddr.hi);
-    printf("ppu_addr lo: decimal:  %d hexa: 0x%x \n", this->reg.ppuAddr.lo, this->reg.ppuAddr.lo);
+    // printf("ppu_addr:  decimal: %d hexa: 0x%x   \n", this->reg.ppuAddr.val, this->reg.ppuAddr.val);
+    // printf("ppu_addr hi: decimal: %d hexa: 0x%x\n", this->reg.ppuAddr.hi, this->reg.ppuAddr.hi);
+    // printf("ppu_addr lo: decimal:  %d hexa: 0x%x \n", this->reg.ppuAddr.lo, this->reg.ppuAddr.lo);
     std::bitset<7> ppu_status(this->reg.ppuStatus.val);
     std::bitset<7> ppu_ctrl(this->reg.ppuCtrl.val);
     std::cout << "ppu status: 0b" << ppu_status << std::endl;
     std::cout << "ppu ctrl: 0b" << ppu_ctrl << std::endl;
-    printf("ppu cycles %d \n", this->cycles);
+    printf("ppu cycles %ld \n", this->cycles);
     printf("OAM Addr hexa: 0x%x decimal: %d \n", this->oam_addr, this->oam_addr);
     printf("\n============================= \n"); //
     printf("\n");
@@ -264,9 +268,10 @@ void PPU::log_ppu()
     qInfo() << "===== OAM  ====";
     qInfo() << "oam addr: " << num_to_hexa(this->oam_addr);
     qInfo() << "=====PPU ADDR=====";
-    qInfo() << "PPU addr:  " << num_to_hexa(this->reg.ppuAddr.val);
-    qInfo() << "lo:  " << num_to_hexa(this->reg.ppuAddr.lo);
-    qInfo() << "hi:  " << num_to_hexa(this->reg.ppuAddr.hi);
+    this->ppuaddr.log();
+    // qInfo() << "PPU addr:  " << num_to_hexa(this->reg.ppuAddr.val);
+    // qInfo() << "lo:  " << num_to_hexa(this->reg.ppuAddr.lo);
+    // qInfo() << "hi:  " << num_to_hexa(this->reg.ppuAddr.hi);
     qInfo() << "";
 
     qInfo() << "===== PPU status ====";
@@ -302,27 +307,27 @@ void PPU::log_ppu()
 }
 void PPU::write_PPU_address(uint8_t val)
 {
+    this->ppuaddr.write_8bit(val);
+    // if (this->reg.high_ptr)
+    // {
+    //     this->reg.ppuAddr.hi = val;
+    // }
+    // else
+    // {
+    //     this->reg.ppuAddr.lo = val;
+    // }
+    // // TODO: fix later
+    // //  std::cout << "ppu addr" << std::endl;
+    // qInfo() << "addr";
+    // qInfo() << "val: " << num_to_hexa(this->reg.ppuAddr.val);
+    // qInfo() << "hi: " << num_to_hexa(this->reg.ppuAddr.hi);
+    // qInfo() << "lo: " << num_to_hexa(this->reg.ppuAddr.lo);
 
-    if (this->reg.high_ptr)
-    {
-        this->reg.ppuAddr.hi = val;
-    }
-    else
-    {
-        this->reg.ppuAddr.lo = val;
-    }
-    // TODO: fix later
-    //  std::cout << "ppu addr" << std::endl;
-    qInfo() << "addr";
-    qInfo() << "val: " << num_to_hexa(this->reg.ppuAddr.val);
-    qInfo() << "hi: " << num_to_hexa(this->reg.ppuAddr.hi);
-    qInfo() << "lo: " << num_to_hexa(this->reg.ppuAddr.lo);
+    // // printf("val:%x   \n", this->reg.ppuAddr.val);
+    // // printf("hi: %x \n", this->reg.ppuAddr.hi);
+    // // printf("lo: %x \n", this->reg.ppuAddr.lo);
 
-    // printf("val:%x   \n", this->reg.ppuAddr.val);
-    // printf("hi: %x \n", this->reg.ppuAddr.hi);
-    // printf("lo: %x \n", this->reg.ppuAddr.lo);
-
-    this->reg.high_ptr = !this->reg.high_ptr;
+    // this->reg.high_ptr = !this->reg.high_ptr;
 }
 void PPU::write_PPU_ctrl(uint8_t val)
 {
@@ -348,7 +353,7 @@ void PPU::write_PPU_mask(uint8_t val)
 std::optional<int> PPU::write_PPU_data(uint8_t val)
 {
 
-    uint16_t addr = this->reg.ppuAddr.val;
+    uint16_t addr = this->ppuaddr.read_16bit();
     if (addr == 0)
         return 1;
     // printf("%x \n", addr);
@@ -396,17 +401,20 @@ std::optional<int> PPU::write_PPU_data(uint8_t val)
         // exit(EXIT_FAILURE);
         if (this->reg.ppumask.s != 0)
         {
-            this->err_string = std::optional<std::string>{"Address 0x" + num_to_hexa(reg.ppuAddr.val) + " is a PPU read only address"};
+            this->err_string = std::optional<std::string>{"Address 0x" + num_to_hexa(this->ppuaddr.read_16bit()) + " is a PPU read only address"};
             return {};
         }
         return 1;
     }
-    this->reg.ppuAddr.val += reg.ppuCtrl.I ? 32 : 1;
-    if (reg.ppuAddr.val > 0x3fff)
+    uint16_t c = this->ppuaddr.read_16bit() + ((reg.ppuCtrl.I) ? 32 : 1);
+    this->ppuaddr.write_16bit(c);
+    // this->reg.ppuAddr.val += reg.ppuCtrl.I ? 32 : 1;
+    if (this->ppuaddr.read_16bit() > 0x3fff)
     {
-        qInfo() << "addr" << num_to_hexa(this->reg.ppuAddr.val) << " val: " << val;
-
-        this->reg.ppuAddr.val &= 0b11111111111111;
+        // qInfo() << "addr" << num_to_hexa(this->reg.ppuAddr.val) << " val: " << val;
+        uint16_t addr_value = this->ppuaddr.read_16bit() & 0b11111111111111;
+        this->ppuaddr.write_16bit(addr_value);
+        // this->reg.ppuAddr.val &= 0b11111111111111;
     }
     return 1;
 }

--- a/src/emulator/PPU.cpp
+++ b/src/emulator/PPU.cpp
@@ -269,9 +269,6 @@ void PPU::log_ppu()
     qInfo() << "oam addr: " << num_to_hexa(this->oam_addr);
     qInfo() << "=====PPU ADDR=====";
     this->ppuaddr.log();
-    // qInfo() << "PPU addr:  " << num_to_hexa(this->reg.ppuAddr.val);
-    // qInfo() << "lo:  " << num_to_hexa(this->reg.ppuAddr.lo);
-    // qInfo() << "hi:  " << num_to_hexa(this->reg.ppuAddr.hi);
     qInfo() << "";
 
     qInfo() << "===== PPU status ====";
@@ -308,26 +305,6 @@ void PPU::log_ppu()
 void PPU::write_PPU_address(uint8_t val)
 {
     this->ppuaddr.write_8bit(val);
-    // if (this->reg.high_ptr)
-    // {
-    //     this->reg.ppuAddr.hi = val;
-    // }
-    // else
-    // {
-    //     this->reg.ppuAddr.lo = val;
-    // }
-    // // TODO: fix later
-    // //  std::cout << "ppu addr" << std::endl;
-    // qInfo() << "addr";
-    // qInfo() << "val: " << num_to_hexa(this->reg.ppuAddr.val);
-    // qInfo() << "hi: " << num_to_hexa(this->reg.ppuAddr.hi);
-    // qInfo() << "lo: " << num_to_hexa(this->reg.ppuAddr.lo);
-
-    // // printf("val:%x   \n", this->reg.ppuAddr.val);
-    // // printf("hi: %x \n", this->reg.ppuAddr.hi);
-    // // printf("lo: %x \n", this->reg.ppuAddr.lo);
-
-    // this->reg.high_ptr = !this->reg.high_ptr;
 }
 void PPU::write_PPU_ctrl(uint8_t val)
 {

--- a/src/emulator/PPU.cpp
+++ b/src/emulator/PPU.cpp
@@ -24,7 +24,8 @@ PPU::PPU(std::vector<uint8_t> chrrom, MirrorType mirrorType)
     for (int i = 0; i < 2048; i++)
         this->memory[i] = 0;
     this->reg.scrollLatch = false;
-    this->reg.ppumask.val = 0;
+    // this->reg.ppumask.val = 0;
+    this->ppumask.reset();
     this->scanline = 0;
     this->cycles = 0;
     this->err_string = std::nullopt;
@@ -262,7 +263,7 @@ void PPU::log_ppu()
 {
     // std::bitset<8> ppu_status(this->reg.ppuStatus.val);
     // std::bitset<8> ppu_ctrl(this->reg.ppuCtrl.val);
-    std::bitset<8> ppu_mask(this->reg.ppumask.val);
+    // std::bitset<8> ppu_mask(this->reg.ppumask.val);
 
     qInfo() << "===== PPU ON EXIT ===========";
     qInfo() << "";
@@ -294,16 +295,17 @@ void PPU::log_ppu()
     // qInfo() << "ctrl: " << ppu_ctrl.to_string();
     qInfo() << "";
     qInfo() << "===== PPU mask ====";
-    qInfo() << "Emphasize blue: " << this->reg.ppumask.B;
-    qInfo() << "Emphasize green: " << this->reg.ppumask.G;
-    qInfo() << "Emphasize red: " << this->reg.ppumask.R;
+    this->ppumask.log();
+    // qInfo() << "Emphasize blue: " << this->reg.ppumask.B;
+    // qInfo() << "Emphasize green: " << this->reg.ppumask.G;
+    // qInfo() << "Emphasize red: " << this->reg.ppumask.R;
 
-    qInfo() << "Enable sprite rendering: " << this->reg.ppumask.s;
-    qInfo() << "Enable background rendering: " << this->reg.ppumask.b;
-    qInfo() << "Show sprites in leftmost 8 pixels of screen: " << this->reg.ppumask.M;
-    qInfo() << "Show background in leftmost 8 pixels of screen " << this->reg.ppumask.m;
-    qInfo() << "grey scale (0: normal color, 1: grey scale): " << this->reg.ppumask.g;
-    qInfo() << "ppu mask: " << ppu_mask.to_string();
+    // qInfo() << "Enable sprite rendering: " << this->reg.ppumask.s;
+    // qInfo() << "Enable background rendering: " << this->reg.ppumask.b;
+    // qInfo() << "Show sprites in leftmost 8 pixels of screen: " << this->reg.ppumask.M;
+    // qInfo() << "Show background in leftmost 8 pixels of screen " << this->reg.ppumask.m;
+    // qInfo() << "grey scale (0: normal color, 1: grey scale): " << this->reg.ppumask.g;
+    // qInfo() << "ppu mask: " << ppu_mask.to_string();
     qInfo() << "";
 }
 void PPU::write_PPU_address(uint8_t val)
@@ -323,12 +325,13 @@ void PPU::write_PPU_ctrl(uint8_t val)
 void PPU::write_PPU_mask(uint8_t val)
 {
 
-    std::bitset<7> ppu_status2(val);
-    std::cout << "mask: " << ppu_status2 << std::endl;
-    std::cout << "ppu mask being written to" << std::endl;
-    this->reg.ppumask.val = val;
-    std::bitset<7> ppu_status(this->reg.ppumask.val);
-    std::cout << "mask: " << ppu_status << std::endl;
+    ppumask.write_8bit(val);
+    // std::bitset<7> ppu_status2(val);
+    // std::cout << "mask: " << ppu_status2 << std::endl;
+    // std::cout << "ppu mask being written to" << std::endl;
+    // this->reg.ppumask.val = val;
+    // std::bitset<7> ppu_status(this->reg.ppumask.val);
+    // std::cout << "mask: " << ppu_status << std::endl;
     // exit(EXIT_FAILURE);
 }
 std::optional<int> PPU::write_PPU_data(uint8_t val)
@@ -380,7 +383,7 @@ std::optional<int> PPU::write_PPU_data(uint8_t val)
         // std::cout << "\033[91mAttempt to write into PPU READ_ONLY_MEM\033[0m" << std::endl;
         // printf("0x%x\n", addr);
         // exit(EXIT_FAILURE);
-        if (this->reg.ppumask.s != 0)
+        if (this->ppumask.get_bit(4) != 0)
         {
             this->err_string = std::optional<std::string>{"Address 0x" + num_to_hexa(this->ppuaddr.read_16bit()) + " is a PPU read only address"};
             return {};
@@ -493,7 +496,7 @@ void PPU::draw_background(std::vector<uint8_t> &rgb_ds, int banks, std::tuple<si
                 upper >>= 1;
                 lower >>= 1;
 
-                auto rgb = getColorFromByte((this->reg.ppumask.b == 1 ? value : 0), bgpallete);
+                auto rgb = getColorFromByte((this->ppumask.get_bit(3) == 1 ? value : 0), bgpallete);
                 // if (value == 0)
                 //     continue;
                 // sf::Color rgb = getColorFromByte(value);

--- a/src/emulator/PPU.cpp
+++ b/src/emulator/PPU.cpp
@@ -205,8 +205,9 @@ uint8_t PPU::read_PPU_data()
 {
     uint16_t addr = this->ppuaddr.read_16bit();
     int inc_mode = this->ppuctrl.get_bit(2); // todo: check
-    uint16_t c = this->ppuaddr.read_16bit() + ((inc_mode) ? 32 : 1);
-    this->ppuaddr.write_16bit(c);
+    this->ppuaddr.increment(inc_mode);
+    // uint16_t c = this->ppuaddr.read_16bit() + ((inc_mode) ? 32 : 1);
+    // this->ppuaddr.write_16bit(c);
     // printf("pallete \n");
     // this->reg.ppuAddr.val += reg.ppuCtrl.I ? 32 : 1;
     if (addr <= 0x1fff)
@@ -387,8 +388,9 @@ std::optional<int> PPU::write_PPU_data(uint8_t val)
         return 1;
     }
     int incmode = this->ppuctrl.get_bit(2);
-    uint16_t c = this->ppuaddr.read_16bit() + ((incmode) ? 32 : 1);
-    this->ppuaddr.write_16bit(c);
+    this->ppuaddr.increment(incmode);
+    // uint16_t c = this->ppuaddr.read_16bit() + ((incmode) ? 32 : 1);
+    // this->ppuaddr.write_16bit(c);
     // this->reg.ppuAddr.val += reg.ppuCtrl.I ? 32 : 1;
     if (this->ppuaddr.read_16bit() > 0x3fff)
     {

--- a/src/emulator/PPU.cpp
+++ b/src/emulator/PPU.cpp
@@ -17,7 +17,8 @@ PPU::PPU(std::vector<uint8_t> chrrom, MirrorType mirrorType)
     this->internalDataBuffer = 0;
     // this->reg.ppuAddr.val = 0;
     this->ppuaddr.reset();
-    this->reg.ppuCtrl.val = 0;
+    this->ppuctrl.reset();
+    // this->reg.ppuCtrl.val = 0;
     // this->reg..val = 0;
     this->ppustatus.reset();
     for (int i = 0; i < 2048; i++)
@@ -203,8 +204,8 @@ uint16_t PPU::mirror(uint16_t address)
 uint8_t PPU::read_PPU_data()
 {
     uint16_t addr = this->ppuaddr.read_16bit();
-
-    uint16_t c = this->ppuaddr.read_16bit() + ((reg.ppuCtrl.I) ? 32 : 1);
+    int inc_mode = this->ppuctrl.get_bit(2); // todo: check
+    uint16_t c = this->ppuaddr.read_16bit() + ((inc_mode) ? 32 : 1);
     this->ppuaddr.write_16bit(c);
     // printf("pallete \n");
     // this->reg.ppuAddr.val += reg.ppuCtrl.I ? 32 : 1;
@@ -248,9 +249,9 @@ void PPU::print_ppu_stats()
     // printf("ppu_addr hi: decimal: %d hexa: 0x%x\n", this->reg.ppuAddr.hi, this->reg.ppuAddr.hi);
     // printf("ppu_addr lo: decimal:  %d hexa: 0x%x \n", this->reg.ppuAddr.lo, this->reg.ppuAddr.lo);
     // std::bitset<7> ppu_status(this->reg.ppuStatus.val);
-    std::bitset<7> ppu_ctrl(this->reg.ppuCtrl.val);
+    // std::bitset<7> ppu_ctrl(this->reg.ppuCtrl.val);
     // std::cout << "ppu status: 0b" << ppu_status << std::endl;
-    std::cout << "ppu ctrl: 0b" << ppu_ctrl << std::endl;
+    // std::cout << "ppu ctrl: 0b" << ppu_ctrl << std::endl;
     printf("ppu cycles %ld \n", this->cycles);
     printf("OAM Addr hexa: 0x%x decimal: %d \n", this->oam_addr, this->oam_addr);
     printf("\n============================= \n"); //
@@ -259,7 +260,7 @@ void PPU::print_ppu_stats()
 void PPU::log_ppu()
 {
     // std::bitset<8> ppu_status(this->reg.ppuStatus.val);
-    std::bitset<8> ppu_ctrl(this->reg.ppuCtrl.val);
+    // std::bitset<8> ppu_ctrl(this->reg.ppuCtrl.val);
     std::bitset<8> ppu_mask(this->reg.ppumask.val);
 
     qInfo() << "===== PPU ON EXIT ===========";
@@ -280,15 +281,16 @@ void PPU::log_ppu()
     qInfo() << "";
 
     qInfo() << "===== PPU ctrl ====";
-    qInfo() << "NMI enable (0: off, 1: on): " << this->reg.ppuCtrl.V;
-    qInfo() << "PPU master/slave select (0: read backdrop from EXT pins; 1: output color on EXT pins): " << this->reg.ppuCtrl.P;
-    qInfo() << "sprite size (0: 8x8, 1: 8x16): " << this->reg.ppuCtrl.H;
-    qInfo() << "Background patterntable (0: $0000; 1: $1000): " << this->reg.ppuCtrl.B;
-    qInfo() << "Sprite patterntable (0: $0000; 1: $1000): " << this->reg.ppuCtrl.S;
-    qInfo() << "increment (0: add 1 going across, 1: add 32 going down): " << this->reg.ppuCtrl.I;
-    std::bitset<2> name_table_address(this->reg.ppuCtrl.N);
-    qInfo() << "name table addreess: " << name_table_address.to_string();
-    qInfo() << "ctrl: " << ppu_ctrl.to_string();
+    this->ppuctrl.log();
+    // qInfo() << "NMI enable (0: off, 1: on): " << this->reg.ppuCtrl.V;
+    // qInfo() << "PPU master/slave select (0: read backdrop from EXT pins; 1: output color on EXT pins): " << this->reg.ppuCtrl.P;
+    // qInfo() << "sprite size (0: 8x8, 1: 8x16): " << this->reg.ppuCtrl.H;
+    // qInfo() << "Background patterntable (0: $0000; 1: $1000): " << this->reg.ppuCtrl.B;
+    // qInfo() << "Sprite patterntable (0: $0000; 1: $1000): " << this->reg.ppuCtrl.S;
+    // qInfo() << "increment (0: add 1 going across, 1: add 32 going down): " << this->reg.ppuCtrl.I;
+    // std::bitset<2> name_table_address(this->reg.ppuCtrl.N);
+    // qInfo() << "name table addreess: " << name_table_address.to_string();
+    // qInfo() << "ctrl: " << ppu_ctrl.to_string();
     qInfo() << "";
     qInfo() << "===== PPU mask ====";
     qInfo() << "Emphasize blue: " << this->reg.ppumask.B;
@@ -309,12 +311,12 @@ void PPU::write_PPU_address(uint8_t val)
 }
 void PPU::write_PPU_ctrl(uint8_t val)
 {
-    auto before = this->reg.ppuCtrl;
-
-    this->reg.ppuCtrl.val = val;
-    if (before.V == 0 && this->reg.ppuCtrl.V == 1 && this->ppustatus.get_bit(7) == 1)
+    auto before = this->ppuctrl.get_bit(7);
+    this->ppuctrl.write_8bit(val);
+    if (before == 0 && this->ppuctrl.get_bit(7) == 1 && this->ppustatus.get_bit(7) == 1)
     {
-        this->reg.ppuCtrl.V = 1;
+        this->ppuctrl.set_bit(7, 1);
+        // this->reg.ppuCtrl.V = 1;
     }
 }
 void PPU::write_PPU_mask(uint8_t val)
@@ -384,7 +386,8 @@ std::optional<int> PPU::write_PPU_data(uint8_t val)
         }
         return 1;
     }
-    uint16_t c = this->ppuaddr.read_16bit() + ((reg.ppuCtrl.I) ? 32 : 1);
+    int incmode = this->ppuctrl.get_bit(2);
+    uint16_t c = this->ppuaddr.read_16bit() + ((incmode) ? 32 : 1);
     this->ppuaddr.write_16bit(c);
     // this->reg.ppuAddr.val += reg.ppuCtrl.I ? 32 : 1;
     if (this->ppuaddr.read_16bit() > 0x3fff)
@@ -414,7 +417,7 @@ bool PPU::tick(uint8_t clock_cycles)
             this->ppustatus.set_bit(7, 1);
             // reg.ppuStatus.V = 1;
             qInfo() << "vblank";
-            if (this->reg.ppuCtrl.V == 1)
+            if (this->ppuctrl.get_bit(7) == 1)
             {
                 // printf("NMI?");
 
@@ -443,7 +446,7 @@ bool PPU::NMI_interrupt(uint8_t clock_cycles)
     if (this->scanline == 241)
     {
         this->ppustatus.set_bit(7, 1);
-        if (this->reg.ppuCtrl.V == 1)
+        if (this->ppuctrl.get_bit(7) == 1)
         {
 
             // printf("%d \n",)
@@ -545,7 +548,7 @@ void PPU::draw_sprites(std::vector<uint8_t> &rgb_ds, int banks, std::tuple<size_
         //  int idx = ppu_idx % 32;
         //  int idy = ppu_idx / 32;
 
-        banks = this->reg.ppuCtrl.B ? 0x1000 : 0;
+        banks = (this->ppuctrl.get_bit(4) == 1) ? 0x1000 : 0;
         std::vector<uint8_t> tile_list;
         auto pallete_idx = attribbyte.pallete;
         // printf("%x \n", attribbyte.pallete);
@@ -630,7 +633,7 @@ void PPU::draw_sprites(std::vector<uint8_t> &rgb_ds, int banks, std::tuple<size_
  */
 std::vector<uint8_t> PPU::render_texture(std::tuple<size_t, size_t> res)
 {
-    int banks = this->reg.ppuCtrl.B ? 0x1000 : 0;
+    int banks = (this->ppuctrl.get_bit(4) == 1) ? 0x1000 : 0;
     std::vector<uint8_t> rgb_ds;
     rgb_ds.resize(std::get<0>(res) * std::get<1>(res) * 4);
 

--- a/src/emulator/PPU.cpp
+++ b/src/emulator/PPU.cpp
@@ -22,7 +22,6 @@ PPU::PPU(std::vector<uint8_t> chrrom, MirrorType mirrorType)
 
     for (int i = 0; i < 2048; i++)
         this->memory[i] = 0;
-    this->reg.high_ptr = true;
     this->reg.scrollLatch = false;
     this->reg.ppumask.val = 0;
     this->scanline = 0;
@@ -233,7 +232,9 @@ uint8_t PPU::read_status()
 {
     uint8_t ret = this->reg.ppuStatus.val;
     this->reg.ppuStatus.V = 0;
-    reg.high_ptr = true;
+    this->ppuaddr.reset_latch();
+    // TODO: fix
+    //  reg.high_ptr = true;
     reg.scrollLatch = false;
     return ret;
 }

--- a/src/emulator/PPU.cpp
+++ b/src/emulator/PPU.cpp
@@ -18,8 +18,8 @@ PPU::PPU(std::vector<uint8_t> chrrom, MirrorType mirrorType)
     // this->reg.ppuAddr.val = 0;
     this->ppuaddr.reset();
     this->reg.ppuCtrl.val = 0;
-    this->reg.ppuStatus.val = 0;
-
+    // this->reg..val = 0;
+    this->ppustatus.reset();
     for (int i = 0; i < 2048; i++)
         this->memory[i] = 0;
     this->reg.scrollLatch = false;
@@ -230,8 +230,9 @@ uint8_t PPU::read_PPU_data()
 }
 uint8_t PPU::read_status()
 {
-    uint8_t ret = this->reg.ppuStatus.val;
-    this->reg.ppuStatus.V = 0;
+    uint8_t ret = this->ppustatus.read_8bit();
+    // this->reg.ppuStatus.V = 0;
+    this->ppustatus.set_bit(7, 0);
     this->ppuaddr.reset_latch();
     // TODO: fix
     //  reg.high_ptr = true;
@@ -248,9 +249,9 @@ void PPU::print_ppu_stats()
     // printf("ppu_addr:  decimal: %d hexa: 0x%x   \n", this->reg.ppuAddr.val, this->reg.ppuAddr.val);
     // printf("ppu_addr hi: decimal: %d hexa: 0x%x\n", this->reg.ppuAddr.hi, this->reg.ppuAddr.hi);
     // printf("ppu_addr lo: decimal:  %d hexa: 0x%x \n", this->reg.ppuAddr.lo, this->reg.ppuAddr.lo);
-    std::bitset<7> ppu_status(this->reg.ppuStatus.val);
+    // std::bitset<7> ppu_status(this->reg.ppuStatus.val);
     std::bitset<7> ppu_ctrl(this->reg.ppuCtrl.val);
-    std::cout << "ppu status: 0b" << ppu_status << std::endl;
+    // std::cout << "ppu status: 0b" << ppu_status << std::endl;
     std::cout << "ppu ctrl: 0b" << ppu_ctrl << std::endl;
     printf("ppu cycles %ld \n", this->cycles);
     printf("OAM Addr hexa: 0x%x decimal: %d \n", this->oam_addr, this->oam_addr);
@@ -259,7 +260,7 @@ void PPU::print_ppu_stats()
 }
 void PPU::log_ppu()
 {
-    std::bitset<8> ppu_status(this->reg.ppuStatus.val);
+    // std::bitset<8> ppu_status(this->reg.ppuStatus.val);
     std::bitset<8> ppu_ctrl(this->reg.ppuCtrl.val);
     std::bitset<8> ppu_mask(this->reg.ppumask.val);
 
@@ -273,10 +274,11 @@ void PPU::log_ppu()
     qInfo() << "";
 
     qInfo() << "===== PPU status ====";
-    qInfo() << "VBlank: " << this->reg.ppuStatus.V;
-    qInfo() << "0_hit: " << this->reg.ppuStatus.S;
-    qInfo() << "overflow: " << this->reg.ppuStatus.O;
-    qInfo() << "status: " << ppu_status.to_string();
+    this->ppustatus.log();
+    // qInfo() << "VBlank: " << this->reg.ppuStatus.V;
+    // qInfo() << "0_hit: " << this->reg.ppuStatus.S;
+    // qInfo() << "overflow: " << this->reg.ppuStatus.O;
+    // qInfo() << "status: " << ppu_status.to_string();
     qInfo() << "";
 
     qInfo() << "===== PPU ctrl ====";
@@ -312,7 +314,7 @@ void PPU::write_PPU_ctrl(uint8_t val)
     auto before = this->reg.ppuCtrl;
 
     this->reg.ppuCtrl.val = val;
-    if (before.V == 0 && this->reg.ppuCtrl.V == 1 && this->reg.ppuStatus.V == 1)
+    if (before.V == 0 && this->reg.ppuCtrl.V == 1 && this->ppustatus.get_bit(7) == 1)
     {
         this->reg.ppuCtrl.V = 1;
     }
@@ -411,7 +413,8 @@ bool PPU::tick(uint8_t clock_cycles)
 
         if (scanline == 241)
         {
-            reg.ppuStatus.V = 1;
+            this->ppustatus.set_bit(7, 1);
+            // reg.ppuStatus.V = 1;
             qInfo() << "vblank";
             if (this->reg.ppuCtrl.V == 1)
             {
@@ -428,7 +431,8 @@ bool PPU::tick(uint8_t clock_cycles)
         {
 
             this->scanline = 0;
-            this->reg.ppuStatus.V = 0;
+            this->ppustatus.set_bit(7, 1);
+            // this->reg.ppuStatus.V = 0;
             qInfo() << "reset";
             return true;
         }
@@ -440,7 +444,7 @@ bool PPU::NMI_interrupt(uint8_t clock_cycles)
 {
     if (this->scanline == 241)
     {
-        this->reg.ppuStatus.V = 1;
+        this->ppustatus.set_bit(7, 1);
         if (this->reg.ppuCtrl.V == 1)
         {
 

--- a/src/emulator/PPU.cpp
+++ b/src/emulator/PPU.cpp
@@ -234,8 +234,6 @@ uint8_t PPU::read_status()
     // this->reg.ppuStatus.V = 0;
     this->ppustatus.set_bit(7, 0);
     this->ppuaddr.reset_latch();
-    // TODO: fix
-    //  reg.high_ptr = true;
     reg.scrollLatch = false;
     return ret;
 }

--- a/src/emulator/component_registers.cpp
+++ b/src/emulator/component_registers.cpp
@@ -1,0 +1,32 @@
+#include <Emulator/component_registers.h>
+
+ComponentRegister::ComponentRegister()
+{
+}
+
+void ComponentRegister::write_8bit(uint8_t value)
+{
+}
+
+uint8_t ComponentRegister::read_8bit()
+{
+    return 0;
+}
+
+void ComponentRegister::write_16bit(uint16_t value)
+{
+}
+
+uint16_t ComponentRegister::read_16bit()
+{
+    return 0;
+}
+
+int ComponentRegister::get_bit(int inudex)
+{
+    return 0;
+}
+
+void ComponentRegister::set_bit(int index)
+{
+}

--- a/src/emulator/component_registers.cpp
+++ b/src/emulator/component_registers.cpp
@@ -22,6 +22,9 @@ uint16_t ComponentRegister::read_16bit()
     return 0;
 }
 
+void ComponentRegister::reset_latch()
+{
+}
 int ComponentRegister::get_bit(int inudex)
 {
     return 0;

--- a/src/emulator/component_registers.cpp
+++ b/src/emulator/component_registers.cpp
@@ -30,6 +30,9 @@ int ComponentRegister::get_bit(int inudex)
     return 0;
 }
 
+void ComponentRegister::increment(int toggle)
+{
+}
 void ComponentRegister::set_bit(int index, int toggle)
 {
 }

--- a/src/emulator/component_registers.cpp
+++ b/src/emulator/component_registers.cpp
@@ -4,6 +4,9 @@ ComponentRegister::ComponentRegister()
 {
 }
 
+/**
+ * read and write
+ */
 void ComponentRegister::write_8bit(uint8_t value)
 {
 }
@@ -22,6 +25,9 @@ uint16_t ComponentRegister::read_16bit()
     return 0;
 }
 
+/**
+ * this resets any toggles
+ */
 void ComponentRegister::reset_latch()
 {
 }
@@ -29,10 +35,16 @@ int ComponentRegister::get_bit(int inudex)
 {
     return 0;
 }
-
-void ComponentRegister::increment(int toggle)
+void ComponentRegister::set_bit(int index, int toggle)
 {
 }
-void ComponentRegister::set_bit(int index, int toggle)
+
+/**
+ * for address registers only
+ * but its job is to increment the value
+ *
+ * the toggle decides if you are supposed to or not
+ */
+void ComponentRegister::increment(int toggle)
 {
 }

--- a/src/emulator/component_registers.cpp
+++ b/src/emulator/component_registers.cpp
@@ -30,6 +30,6 @@ int ComponentRegister::get_bit(int inudex)
     return 0;
 }
 
-void ComponentRegister::set_bit(int index)
+void ComponentRegister::set_bit(int index, int toggle)
 {
 }

--- a/src/emulator/ppu_address.cpp
+++ b/src/emulator/ppu_address.cpp
@@ -1,7 +1,10 @@
-#include <Emulator/component_registers.h>
+#include <Emulator/ppu_components.h>
+#include <Qt/util.h>
+#include <QDebug>
 
 PPUAddress::PPUAddress()
 {
+    this->reset();
 }
 
 void PPUAddress::write_8bit(uint8_t value)
@@ -34,4 +37,7 @@ void PPUAddress::reset()
 
 void PPUAddress::log()
 {
+    qInfo() << "PPU addr:  " << num_to_hexa(this->ppuAddr.val);
+    qInfo() << "lo:  " << num_to_hexa(this->ppuAddr.lo);
+    qInfo() << "hi:  " << num_to_hexa(this->ppuAddr.hi);
 }

--- a/src/emulator/ppu_address.cpp
+++ b/src/emulator/ppu_address.cpp
@@ -41,3 +41,8 @@ void PPUAddress::log()
     qInfo() << "lo:  " << num_to_hexa(this->ppuAddr.lo);
     qInfo() << "hi:  " << num_to_hexa(this->ppuAddr.hi);
 }
+
+void PPUAddress::reset_latch()
+{
+    this->high_ptr = true;
+}

--- a/src/emulator/ppu_address.cpp
+++ b/src/emulator/ppu_address.cpp
@@ -4,16 +4,32 @@ PPUAddress::PPUAddress()
 {
 }
 
+void PPUAddress::write_8bit(uint8_t value)
+{
+    if (this->high_ptr)
+    {
+        this->ppuAddr.hi = value;
+    }
+    else
+    {
+        this->ppuAddr.lo = value;
+    }
+    this->high_ptr = !high_ptr;
+}
+
 void PPUAddress::write_16bit(uint16_t value)
 {
+    this->ppuAddr.val = value;
 }
 uint16_t PPUAddress::read_16bit()
 {
-    return 0;
+    return this->ppuAddr.val;
 }
 
 void PPUAddress::reset()
 {
+    this->ppuAddr.val = 0;
+    this->high_ptr = true;
 }
 
 void PPUAddress::log()

--- a/src/emulator/ppu_address.cpp
+++ b/src/emulator/ppu_address.cpp
@@ -42,6 +42,17 @@ void PPUAddress::log()
     qInfo() << "hi:  " << num_to_hexa(this->ppuAddr.hi);
 }
 
+void PPUAddress::increment(int toggle)
+{
+    if (toggle == 1)
+    {
+        this->ppuAddr.val += 32;
+    }
+    else
+    {
+        this->ppuAddr.val += 1;
+    }
+}
 void PPUAddress::reset_latch()
 {
     this->high_ptr = true;

--- a/src/emulator/ppu_address.cpp
+++ b/src/emulator/ppu_address.cpp
@@ -1,0 +1,21 @@
+#include <Emulator/component_registers.h>
+
+PPUAddress::PPUAddress()
+{
+}
+
+void PPUAddress::write_16bit(uint16_t value)
+{
+}
+uint16_t PPUAddress::read_16bit()
+{
+    return 0;
+}
+
+void PPUAddress::reset()
+{
+}
+
+void PPUAddress::log()
+{
+}

--- a/src/emulator/ppu_control.cpp
+++ b/src/emulator/ppu_control.cpp
@@ -1,0 +1,56 @@
+#include <Emulator/ppu_components.h>
+#include <QDebug>
+#include <bitset>
+PPUControl::PPUControl()
+{
+    this->reset();
+}
+
+void PPUControl::reset()
+{
+    this->ppuCtrl.val = 0;
+}
+void PPUControl::log()
+{
+    std::bitset<8> ppu_ctrl(this->ppuCtrl.val);
+    qInfo() << "NMI enable (0: off, 1: on): " << this->ppuCtrl.V;
+    qInfo() << "PPU master/slave select (0: read backdrop from EXT pins; 1: output color on EXT pins): "
+            << this->ppuCtrl.P;
+    qInfo() << "sprite size (0: 8x8, 1: 8x16): " << this->ppuCtrl.H;
+    qInfo() << "Background patterntable (0: $0000; 1: $1000): " << this->ppuCtrl.B;
+    qInfo() << "Sprite patterntable (0: $0000; 1: $1000): " << this->ppuCtrl.S;
+    qInfo() << "increment (0: add 1 going across, 1: add 32 going down): " << this->ppuCtrl.I;
+    std::bitset<2> name_table_address(this->ppuCtrl.N);
+    qInfo() << "name table addreess: " << name_table_address.to_string();
+    qInfo() << "ctrl: " << ppu_ctrl.to_string();
+}
+void PPUControl::set_bit(int index, int toggle)
+{
+    if (toggle == 1)
+    {
+        uint8_t mask = 1 << index;
+        this->ppuCtrl.val |= mask;
+    }
+    else
+    {
+        uint8_t mask = (1 << index);
+        this->ppuCtrl.val &= (~mask);
+    }
+}
+
+int PPUControl::get_bit(int index)
+{
+    return (this->ppuCtrl.val >> index) & 1;
+}
+
+uint8_t PPUControl::read_8bit()
+{
+    return this->ppuCtrl.val;
+}
+
+void PPUControl::write_8bit(uint8_t value)
+{
+    this->ppuCtrl.val = value;
+}
+
+//

--- a/src/emulator/ppu_mask.cpp
+++ b/src/emulator/ppu_mask.cpp
@@ -1,20 +1,52 @@
 #include <Emulator/ppu_components.h>
+#include <QDebug>
+#include <bitset>
+PPUMask::PPUMask()
+{
+    this->reset();
+}
 
-PPUMask::PPUMask() {}
+void PPUMask::log()
+{
+    std::bitset<8> ppu_mask(this->ppumask.val);
+    qInfo() << "Emphasize blue: " << this->ppumask.B;
+    qInfo() << "Emphasize green: " << this->ppumask.G;
+    qInfo() << "Emphasize red: " << this->ppumask.R;
 
-void PPUMask::log() {}
+    qInfo() << "Enable sprite rendering: " << this->ppumask.s;
+    qInfo() << "Enable background rendering: " << this->ppumask.b;
+    qInfo() << "Show sprites in leftmost 8 pixels of screen: " << this->ppumask.M;
+    qInfo() << "Show background in leftmost 8 pixels of screen " << this->ppumask.m;
+    qInfo() << "grey scale (0: normal color, 1: grey scale): " << this->ppumask.g;
+    qInfo() << "ppu mask: " << ppu_mask.to_string();
+}
 
 void PPUMask::reset()
 {
+    this->ppumask.val = 0b00000000;
 }
 
+void PPUMask::write_8bit(uint8_t value)
+{
+    this->ppumask.val = value;
+}
 void PPUMask::set_bit(int index, int toggle)
 {
+    if (toggle == 1)
+    {
+        uint8_t mask = 1 << index;
+        this->ppumask.val |= mask;
+    }
+    else
+    {
+        uint8_t mask = (1 << index);
+        this->ppumask.val &= (~mask);
+    }
 }
 
 int PPUMask::get_bit(int index)
 {
-    return 0;
+    return (this->ppumask.val >> index) & 1;
 }
 
 //

--- a/src/emulator/ppu_mask.cpp
+++ b/src/emulator/ppu_mask.cpp
@@ -1,0 +1,20 @@
+#include <Emulator/ppu_components.h>
+
+PPUMask::PPUMask() {}
+
+void PPUMask::log() {}
+
+void PPUMask::reset()
+{
+}
+
+void PPUMask::set_bit(int index, int toggle)
+{
+}
+
+int PPUMask::get_bit(int index)
+{
+    return 0;
+}
+
+//

--- a/src/emulator/ppu_status.cpp
+++ b/src/emulator/ppu_status.cpp
@@ -11,7 +11,6 @@ void PPUStatus::log()
 {
 
     std::bitset<8> ppu_status(ppuStatus.val);
-    qInfo() << "===== PPU status ====";
     qInfo() << "VBlank: " << this->ppuStatus.V;
     qInfo() << "0_hit: " << this->ppuStatus.S;
     qInfo() << "overflow: " << this->ppuStatus.O;

--- a/src/emulator/ppu_status.cpp
+++ b/src/emulator/ppu_status.cpp
@@ -37,7 +37,6 @@ uint8_t PPUStatus::read_8bit()
 void PPUStatus::set_bit(int index, int toggle)
 {
 
-    // TODO: check math
     if (toggle == 1)
     {
         uint8_t mask = 1 << index;
@@ -46,7 +45,7 @@ void PPUStatus::set_bit(int index, int toggle)
     else
     {
         uint8_t mask = (1 << index);
-        this->ppuStatus.val &= ~mask;
+        this->ppuStatus.val &= (~mask);
     }
 }
 

--- a/src/emulator/ppu_status.cpp
+++ b/src/emulator/ppu_status.cpp
@@ -1,0 +1,31 @@
+#include <Emulator/ppu_components.h>
+
+int PPUStatus::get_bit(int index)
+
+{
+}
+
+void PPUStatus::log()
+{
+}
+
+void PPUStatus::reset()
+{
+}
+
+PPUStatus::PPUStatus()
+{
+}
+
+void PPUStatus::write_8bit(uint8_t value)
+{
+}
+
+uint8_t PPUStatus::read_8bit()
+{
+    return 0;
+}
+
+void PPUStatus::set_bit(int index)
+{
+}

--- a/src/emulator/ppu_status.cpp
+++ b/src/emulator/ppu_status.cpp
@@ -10,7 +10,7 @@ PPUStatus::PPUStatus()
 void PPUStatus::log()
 {
 
-    std::bitset<7> ppu_status(ppuStatus.val);
+    std::bitset<8> ppu_status(ppuStatus.val);
     qInfo() << "===== PPU status ====";
     qInfo() << "VBlank: " << this->ppuStatus.V;
     qInfo() << "0_hit: " << this->ppuStatus.S;
@@ -36,6 +36,8 @@ uint8_t PPUStatus::read_8bit()
 
 void PPUStatus::set_bit(int index, int toggle)
 {
+
+    // TODO: check math
     if (toggle == 1)
     {
         uint8_t mask = 1 << index;
@@ -43,13 +45,13 @@ void PPUStatus::set_bit(int index, int toggle)
     }
     else
     {
-        uint8_t mask = ~(1 << index);
-        this->ppuStatus.val |= mask;
+        uint8_t mask = (1 << index);
+        this->ppuStatus.val &= ~mask;
     }
 }
 
 int PPUStatus::get_bit(int index)
 {
-
+    qInfo() << "get bit of status: " << std::to_string((this->ppuStatus.val >> index) & 1);
     return (this->ppuStatus.val >> index) & 1;
 }

--- a/src/emulator/ppu_status.cpp
+++ b/src/emulator/ppu_status.cpp
@@ -1,31 +1,55 @@
 #include <Emulator/ppu_components.h>
+#include <bitset>
+#include <QDebug>
 
-int PPUStatus::get_bit(int index)
-
+PPUStatus::PPUStatus()
 {
+    this->reset();
 }
 
 void PPUStatus::log()
 {
+
+    std::bitset<7> ppu_status(ppuStatus.val);
+    qInfo() << "===== PPU status ====";
+    qInfo() << "VBlank: " << this->ppuStatus.V;
+    qInfo() << "0_hit: " << this->ppuStatus.S;
+    qInfo() << "overflow: " << this->ppuStatus.O;
+    qInfo() << "status: " << ppu_status.to_string();
+    qInfo() << "";
 }
 
 void PPUStatus::reset()
 {
-}
-
-PPUStatus::PPUStatus()
-{
+    this->ppuStatus.val = 0;
 }
 
 void PPUStatus::write_8bit(uint8_t value)
 {
+    this->ppuStatus.val = value;
 }
 
 uint8_t PPUStatus::read_8bit()
 {
-    return 0;
+    return this->ppuStatus.val;
 }
 
-void PPUStatus::set_bit(int index)
+void PPUStatus::set_bit(int index, int toggle)
 {
+    if (toggle == 1)
+    {
+        uint8_t mask = 1 << index;
+        this->ppuStatus.val |= mask;
+    }
+    else
+    {
+        uint8_t mask = ~(1 << index);
+        this->ppuStatus.val |= mask;
+    }
+}
+
+int PPUStatus::get_bit(int index)
+{
+
+    return (this->ppuStatus.val >> index) & 1;
 }

--- a/src/include/Emulator/PPU.h
+++ b/src/include/Emulator/PPU.h
@@ -18,6 +18,7 @@ private:
     void get_chr_tile(uint16_t tile_idx, int banks, std::vector<uint8_t> &tile_list);
     PPUAddress ppuaddr;
     PPUStatus ppustatus;
+    PPUControl ppuctrl;
     // sf::Color getColorFromByte(uint16_t byte);
     struct Registers
     {
@@ -46,25 +47,25 @@ private:
         //     };
         //     uint16_t val;
         // } ppuAddr;
-        union
-        {
-            struct
-            {
-                unsigned N : 2; // increment mode
-                unsigned I : 1; // increment mode
-                unsigned S : 1; // sprite tile select (ignored in 8x16 sprite mode)
+        // union
+        // {
+        //     struct
+        //     {
+        //         unsigned N : 2; // increment mode
+        //         unsigned I : 1; // increment mode
+        //         unsigned S : 1; // sprite tile select (ignored in 8x16 sprite mode)
 
-                unsigned B : 1; // background tile select
+        //         unsigned B : 1; // background tile select
 
-                unsigned H : 1; // sprite height
+        //         unsigned H : 1; // sprite height
 
-                unsigned P : 1; // PPU master/slave
+        //         unsigned P : 1; // PPU master/slave
 
-                unsigned V : 1; // NMI enable
-            };
-            uint8_t val;
+        //         unsigned V : 1; // NMI enable
+        //     };
+        //     uint8_t val;
 
-        } ppuCtrl;
+        // } ppuCtrl;
         // union
         // {
         //     struct

--- a/src/include/Emulator/PPU.h
+++ b/src/include/Emulator/PPU.h
@@ -13,6 +13,7 @@
 class PPU
 {
 private:
+    PPUMask ppumask;
     std::tuple<uint8_t, uint8_t, uint8_t, uint8_t> bg_pallete(size_t row, size_t column);
     std::tuple<uint8_t, uint8_t, uint8_t> getColorFromByte(uint16_t byte, std::tuple<uint8_t, uint8_t, uint8_t, uint8_t> pallete);
     void get_chr_tile(uint16_t tile_idx, int banks, std::vector<uint8_t> &tile_list);
@@ -22,22 +23,22 @@ private:
     // sf::Color getColorFromByte(uint16_t byte);
     struct Registers
     {
-        union
-        {
-            struct
-            {
-                unsigned g : 1; // greyscale
-                unsigned m : 1; // background left column disable
-                unsigned M : 1; // sprite left column disable
-                unsigned b : 1; // background enable
+        // union
+        // {
+        //     struct
+        //     {
+        //         unsigned g : 1; // greyscale
+        //         unsigned m : 1; // background left column disable
+        //         unsigned M : 1; // sprite left column disable
+        //         unsigned b : 1; // background enable
 
-                unsigned s : 1; // sprite enable
-                unsigned R : 1; // color emphasis Red
-                unsigned G : 1; // color emphasis Green
-                unsigned B : 1; // color emphasis Blue
-            };
-            uint8_t val;
-        } ppumask;
+        //         unsigned s : 1; // sprite enable
+        //         unsigned R : 1; // color emphasis Red
+        //         unsigned G : 1; // color emphasis Green
+        //         unsigned B : 1; // color emphasis Blue
+        //     };
+        //     uint8_t val;
+        // } ppumask;
         // union
         // {
         //     struct

--- a/src/include/Emulator/PPU.h
+++ b/src/include/Emulator/PPU.h
@@ -17,6 +17,7 @@ private:
     std::tuple<uint8_t, uint8_t, uint8_t> getColorFromByte(uint16_t byte, std::tuple<uint8_t, uint8_t, uint8_t, uint8_t> pallete);
     void get_chr_tile(uint16_t tile_idx, int banks, std::vector<uint8_t> &tile_list);
     PPUAddress ppuaddr;
+    PPUStatus ppustatus;
     // sf::Color getColorFromByte(uint16_t byte);
     struct Registers
     {
@@ -64,21 +65,21 @@ private:
             uint8_t val;
 
         } ppuCtrl;
-        union
-        {
-            struct
-            {
-                unsigned padding : 5;
+        // union
+        // {
+        //     struct
+        //     {
+        //         unsigned padding : 5;
 
-                unsigned O : 1;
-                unsigned S : 1;
-                // unsigned : 1;
+        //         unsigned O : 1;
+        //         unsigned S : 1;
+        //         // unsigned : 1;
 
-                unsigned V : 1;
-            };
-            uint8_t val;
+        //         unsigned V : 1;
+        //     };
+        //     uint8_t val;
 
-        } ppuStatus;
+        // } ppuStatus;
         bool scrollLatch;
         // bool high_ptr;
     };

--- a/src/include/Emulator/PPU.h
+++ b/src/include/Emulator/PPU.h
@@ -80,7 +80,7 @@ private:
 
         } ppuStatus;
         bool scrollLatch;
-        bool high_ptr;
+        // bool high_ptr;
     };
     uint8_t memory[0x800];
     Registers reg;

--- a/src/include/Emulator/PPU.h
+++ b/src/include/Emulator/PPU.h
@@ -8,7 +8,7 @@
 #include <optional>
 #include <tuple>
 #include <chrono>
-
+#include <Emulator/ppu_components.h>
 #include <cstdint>
 class PPU
 {
@@ -16,6 +16,7 @@ private:
     std::tuple<uint8_t, uint8_t, uint8_t, uint8_t> bg_pallete(size_t row, size_t column);
     std::tuple<uint8_t, uint8_t, uint8_t> getColorFromByte(uint16_t byte, std::tuple<uint8_t, uint8_t, uint8_t, uint8_t> pallete);
     void get_chr_tile(uint16_t tile_idx, int banks, std::vector<uint8_t> &tile_list);
+    PPUAddress ppuaddr;
     // sf::Color getColorFromByte(uint16_t byte);
     struct Registers
     {
@@ -35,15 +36,15 @@ private:
             };
             uint8_t val;
         } ppumask;
-        union
-        {
-            struct
-            {
-                unsigned lo : 8;
-                unsigned hi : 8;
-            };
-            uint16_t val;
-        } ppuAddr;
+        // union
+        // {
+        //     struct
+        //     {
+        //         unsigned lo : 8;
+        //         unsigned hi : 8;
+        //     };
+        //     uint16_t val;
+        // } ppuAddr;
         union
         {
             struct
@@ -84,6 +85,7 @@ private:
     uint8_t memory[0x800];
     Registers reg;
     std::vector<uint8_t> chr_rom;
+
     uint8_t oam[256];
     uint8_t oam_addr;
     uint8_t pallete[0x20];

--- a/src/include/Emulator/PPU.h
+++ b/src/include/Emulator/PPU.h
@@ -13,77 +13,16 @@
 class PPU
 {
 private:
-    PPUMask ppumask;
     std::tuple<uint8_t, uint8_t, uint8_t, uint8_t> bg_pallete(size_t row, size_t column);
     std::tuple<uint8_t, uint8_t, uint8_t> getColorFromByte(uint16_t byte, std::tuple<uint8_t, uint8_t, uint8_t, uint8_t> pallete);
     void get_chr_tile(uint16_t tile_idx, int banks, std::vector<uint8_t> &tile_list);
+    PPUMask ppumask;
     PPUAddress ppuaddr;
     PPUStatus ppustatus;
     PPUControl ppuctrl;
-    // sf::Color getColorFromByte(uint16_t byte);
     struct Registers
     {
-        // union
-        // {
-        //     struct
-        //     {
-        //         unsigned g : 1; // greyscale
-        //         unsigned m : 1; // background left column disable
-        //         unsigned M : 1; // sprite left column disable
-        //         unsigned b : 1; // background enable
-
-        //         unsigned s : 1; // sprite enable
-        //         unsigned R : 1; // color emphasis Red
-        //         unsigned G : 1; // color emphasis Green
-        //         unsigned B : 1; // color emphasis Blue
-        //     };
-        //     uint8_t val;
-        // } ppumask;
-        // union
-        // {
-        //     struct
-        //     {
-        //         unsigned lo : 8;
-        //         unsigned hi : 8;
-        //     };
-        //     uint16_t val;
-        // } ppuAddr;
-        // union
-        // {
-        //     struct
-        //     {
-        //         unsigned N : 2; // increment mode
-        //         unsigned I : 1; // increment mode
-        //         unsigned S : 1; // sprite tile select (ignored in 8x16 sprite mode)
-
-        //         unsigned B : 1; // background tile select
-
-        //         unsigned H : 1; // sprite height
-
-        //         unsigned P : 1; // PPU master/slave
-
-        //         unsigned V : 1; // NMI enable
-        //     };
-        //     uint8_t val;
-
-        // } ppuCtrl;
-        // union
-        // {
-        //     struct
-        //     {
-        //         unsigned padding : 5;
-
-        //         unsigned O : 1;
-        //         unsigned S : 1;
-        //         // unsigned : 1;
-
-        //         unsigned V : 1;
-        //     };
-        //     uint8_t val;
-
-        // } ppuStatus;
         bool scrollLatch;
-        // bool high_ptr;
     };
     uint8_t memory[0x800];
     Registers reg;

--- a/src/include/Emulator/component_registers.h
+++ b/src/include/Emulator/component_registers.h
@@ -1,0 +1,32 @@
+#include <stdint.h>
+
+#ifndef COMPONENT_H
+#define COMPONENT_H
+class ComponentRegister
+{
+public:
+    ComponentRegister();
+    virtual void write_8bit(uint8_t value);
+    virtual uint8_t read_8bit();
+    virtual void write_16bit(uint16_t value);
+    virtual uint16_t read_16bit();
+    virtual void reset() = 0;
+    virtual void log() = 0;
+    virtual int get_bit(int inudex);
+    virtual void set_bit(int index);
+};
+#endif
+
+#ifndef PPU_Address_H
+#define PPU_Address_H
+class PPUAddress : public ComponentRegister
+{
+private:
+public:
+    PPUAddress();
+    void write_16bit(uint16_t value) override;
+    uint16_t read_16bit() override;
+    void reset() override;
+    void log() override;
+};
+#endif

--- a/src/include/Emulator/component_registers.h
+++ b/src/include/Emulator/component_registers.h
@@ -19,8 +19,10 @@ public:
     virtual void write_16bit(uint16_t value);
     virtual uint16_t read_16bit();
     virtual void reset() = 0;
+    virtual void reset_latch();
     virtual void log() = 0;
-    virtual int get_bit(int inudex);
+    virtual int get_bit(int index);
+
     virtual void set_bit(int index);
 };
 #endif

--- a/src/include/Emulator/component_registers.h
+++ b/src/include/Emulator/component_registers.h
@@ -22,8 +22,20 @@ public:
 class PPUAddress : public ComponentRegister
 {
 private:
+    bool high_ptr;
+    union
+    {
+        struct
+        {
+            unsigned lo : 8;
+            unsigned hi : 8;
+        };
+        uint16_t val;
+    } ppuAddr;
+
 public:
     PPUAddress();
+    void write_8bit(uint8_t value) override;
     void write_16bit(uint16_t value) override;
     uint16_t read_16bit() override;
     void reset() override;

--- a/src/include/Emulator/component_registers.h
+++ b/src/include/Emulator/component_registers.h
@@ -16,29 +16,3 @@ public:
     virtual void set_bit(int index);
 };
 #endif
-
-#ifndef PPU_Address_H
-#define PPU_Address_H
-class PPUAddress : public ComponentRegister
-{
-private:
-    bool high_ptr;
-    union
-    {
-        struct
-        {
-            unsigned lo : 8;
-            unsigned hi : 8;
-        };
-        uint16_t val;
-    } ppuAddr;
-
-public:
-    PPUAddress();
-    void write_8bit(uint8_t value) override;
-    void write_16bit(uint16_t value) override;
-    uint16_t read_16bit() override;
-    void reset() override;
-    void log() override;
-};
-#endif

--- a/src/include/Emulator/component_registers.h
+++ b/src/include/Emulator/component_registers.h
@@ -22,6 +22,7 @@ public:
     virtual void reset_latch();
     virtual void log() = 0;
     virtual int get_bit(int index);
+    virtual void increment(int toggle);
 
     virtual void set_bit(int index, int toggle);
 };

--- a/src/include/Emulator/component_registers.h
+++ b/src/include/Emulator/component_registers.h
@@ -1,5 +1,13 @@
 #include <stdint.h>
 
+/*
+
+for the NES's many memory mapped devices. this will be the class
+
+that we will have each one
+extend such as PPU addr, PPU ctrl, PPU status...
+
+*/
 #ifndef COMPONENT_H
 #define COMPONENT_H
 class ComponentRegister

--- a/src/include/Emulator/component_registers.h
+++ b/src/include/Emulator/component_registers.h
@@ -23,6 +23,6 @@ public:
     virtual void log() = 0;
     virtual int get_bit(int index);
 
-    virtual void set_bit(int index);
+    virtual void set_bit(int index, int toggle);
 };
 #endif

--- a/src/include/Emulator/ppu_components.h
+++ b/src/include/Emulator/ppu_components.h
@@ -31,13 +31,25 @@ public:
 class PPUStatus : public ComponentRegister
 {
 private:
-    uint8_t status;
+    union
+    {
+        struct
+        {
+            unsigned padding : 5;
+
+            unsigned O : 1;
+            unsigned S : 1;
+            unsigned V : 1;
+        };
+        uint8_t val;
+
+    } ppuStatus;
 
 public:
     PPUStatus();
     void write_8bit(uint8_t value) override;
     uint8_t read_8bit() override;
-    void set_bit(int index) override;
+    void set_bit(int index, int toggle) override;
     int get_bit(int index) override;
     void log() override;
     void reset() override;

--- a/src/include/Emulator/ppu_components.h
+++ b/src/include/Emulator/ppu_components.h
@@ -22,5 +22,6 @@ public:
     uint16_t read_16bit() override;
     void reset() override;
     void log() override;
+    void reset_latch() override;
 };
 #endif

--- a/src/include/Emulator/ppu_components.h
+++ b/src/include/Emulator/ppu_components.h
@@ -55,3 +55,52 @@ public:
     void reset() override;
 };
 #endif
+
+#ifndef PPU_MASK_H
+#define PPU_MASK_H
+class PPUMask : public ComponentRegister
+{
+public:
+    PPUMask();
+    void reset() override;
+    void log() override;
+    void set_bit(int index, int toggle) override;
+    int get_bit(int index) override;
+};
+#endif
+
+#ifndef PPU_Ctrl_H
+#define PPU_Ctrl_H
+class PPUControl : public ComponentRegister
+{
+private:
+    union
+    {
+        struct
+        {
+            unsigned N : 2; // increment mode
+            unsigned I : 1; // increment mode
+            unsigned S : 1; // sprite tile select (ignored in 8x16 sprite mode)
+
+            unsigned B : 1; // background tile select
+
+            unsigned H : 1; // sprite height
+
+            unsigned P : 1; // PPU master/slave
+
+            unsigned V : 1; // NMI enable
+        };
+        uint8_t val;
+
+    } ppuCtrl;
+
+public:
+    PPUControl();
+    void reset() override;
+    void log() override;
+    void set_bit(int index, int toggle) override;
+    int get_bit(int index) override;
+    uint8_t read_8bit() override;
+    void write_8bit(uint8_t value) override;
+};
+#endif

--- a/src/include/Emulator/ppu_components.h
+++ b/src/include/Emulator/ppu_components.h
@@ -22,6 +22,7 @@ public:
     uint16_t read_16bit() override;
     void reset() override;
     void log() override;
+    void increment(int toggle) override;
     void reset_latch() override;
 };
 #endif

--- a/src/include/Emulator/ppu_components.h
+++ b/src/include/Emulator/ppu_components.h
@@ -61,12 +61,31 @@ public:
 #define PPU_MASK_H
 class PPUMask : public ComponentRegister
 {
+private:
+    union
+    {
+        struct
+        {
+            unsigned g : 1; // greyscale
+            unsigned m : 1; // background left column disable
+            unsigned M : 1; // sprite left column disable
+            unsigned b : 1; // background enable
+
+            unsigned s : 1; // sprite enable
+            unsigned R : 1; // color emphasis Red
+            unsigned G : 1; // color emphasis Green
+            unsigned B : 1; // color emphasis Blue
+        };
+        uint8_t val;
+    } ppumask;
+
 public:
     PPUMask();
     void reset() override;
     void log() override;
     void set_bit(int index, int toggle) override;
     int get_bit(int index) override;
+    void write_8bit(uint8_t value) override;
 };
 #endif
 

--- a/src/include/Emulator/ppu_components.h
+++ b/src/include/Emulator/ppu_components.h
@@ -1,0 +1,26 @@
+#include <Emulator/component_registers.h>
+#ifndef PPU_Address_H
+#define PPU_Address_H
+class PPUAddress : public ComponentRegister
+{
+private:
+    bool high_ptr;
+    union
+    {
+        struct
+        {
+            unsigned lo : 8;
+            unsigned hi : 8;
+        };
+        uint16_t val;
+    } ppuAddr;
+
+public:
+    PPUAddress();
+    void write_8bit(uint8_t value) override;
+    void write_16bit(uint16_t value) override;
+    uint16_t read_16bit() override;
+    void reset() override;
+    void log() override;
+};
+#endif

--- a/src/include/Emulator/ppu_components.h
+++ b/src/include/Emulator/ppu_components.h
@@ -25,3 +25,21 @@ public:
     void reset_latch() override;
 };
 #endif
+
+#ifndef PPU_Status_H
+#define PPU_Status_H
+class PPUStatus : public ComponentRegister
+{
+private:
+    uint8_t status;
+
+public:
+    PPUStatus();
+    void write_8bit(uint8_t value) override;
+    uint8_t read_8bit() override;
+    void set_bit(int index) override;
+    int get_bit(int index) override;
+    void log() override;
+    void reset() override;
+};
+#endif

--- a/src/include/Qt/settingswidget.h
+++ b/src/include/Qt/settingswidget.h
@@ -11,7 +11,7 @@
 
 #include <Qt/settingsdisplay.h>
 
-//class SettingsDisplay; // TODO: Foward declaration, prevents "'SettingsDisplay' does not name a type" error
+// class SettingsDisplay; // TODO: Foward declaration, prevents "'SettingsDisplay' does not name a type" error
 class SettingsWidget : public QWidget
 {
     Q_OBJECT
@@ -35,5 +35,4 @@ private slots:
 
 protected:
     void closeEvent(QCloseEvent *event) override;
-    
 };


### PR DESCRIPTION
moduarlize it 
and make it more abstract and generic. 

so we can reuse it for other memory mapped components.

as well as mappers in the future. 